### PR TITLE
Fix duplicate email extraction

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -125,7 +125,9 @@ class Parser {
         }
 
         String extractEmails(String pageContent) {
-            List<String> emails = new ArrayList<>();
+            // Use a set to automatically remove duplicates while preserving
+            // the order of discovery so test expectations remain stable.
+            Set<String> emails = new LinkedHashSet<>();
             Matcher matcher = pattern.matcher(pageContent);
             while (matcher.find()) {
                 String email = matcher.group("value");


### PR DESCRIPTION
## Summary
- ensure Parser removes duplicate emails by using a `LinkedHashSet`

## Testing
- `mvn test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6856cbdc68b8832b96de061c3ad5103f