### PR TITLE
Fix duplicate phone numbers

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -101,6 +101,9 @@ class Parser {
 
             removeShortestPhoneNumbers(phoneNumbers);
 
+            // Remove duplicate numbers while keeping the original order
+            phoneNumbers = new ArrayList<>(new LinkedHashSet<>(phoneNumbers));
+
             return phoneNumbers.stream().collect(Collectors.joining("◙"));
         }
 

--- a/src/test/java/bc/bfi/crawler/ParserTest.java
+++ b/src/test/java/bc/bfi/crawler/ParserTest.java
@@ -1,0 +1,13 @@
+package bc.bfi.crawler;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ParserTest {
+    @Test
+    public void testExtractPhoneRemovesDuplicates() {
+        bc.bfi.crawler.Parser parser = new bc.bfi.crawler.Parser();
+        String html = "Contact 123-456-7890 or 456-7890 call 123-456-7890";
+        String phones = parser.extractPhone(html);
+        assertEquals("123-456-7890", phones);
+    }
+}


### PR DESCRIPTION
## Summary
- dedupe phone numbers in `Parser`
- add a unit test to prove duplicate removal

## Testing
- `javac -d out src/main/java/bc/bfi/crawler/Parser.java src/main/java/bc/bfi/crawler/Utils.java src/main/java/bc/bfi/crawler/Website.java src/test/java/bc/bfi/crawler/ParserTest.java -cp /usr/share/java/junit4.jar`
- `java -cp out:/usr/share/java/junit4.jar:/usr/share/java/hamcrest-core.jar org.junit.runner.JUnitCore bc.bfi.crawler.ParserTest`

------
https://chatgpt.com/codex/tasks/task_b_6856cc76e9a0832b8ea37d69356e791c