### PR TITLE
Normalize URLs

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -192,7 +192,7 @@ class Parser {
 
             String contactPageUrl = candidateLinks.get(0);
             contactPageUrl = appendHostname(contactPageUrl, url);
-            return contactPageUrl;
+            return normalizeContactUrl(contactPageUrl);
         }
 
         private String appendHostname(String contactPageUrl, String url) {
@@ -200,6 +200,18 @@ class Parser {
                 contactPageUrl = Utils.extractBaseUrl(url) + contactPageUrl;
             }
 
+            return contactPageUrl;
+        }
+
+        private String normalizeContactUrl(String contactPageUrl) {
+            if (contactPageUrl == null) {
+                return "";
+            }
+
+            contactPageUrl = contactPageUrl.trim();
+            if (contactPageUrl.endsWith("/")) {
+                contactPageUrl = contactPageUrl.substring(0, contactPageUrl.length() - 1);
+            }
             return contactPageUrl;
         }
 

--- a/src/test/java/bc/bfi/crawler/ContactAndSocialNormalizationTest.java
+++ b/src/test/java/bc/bfi/crawler/ContactAndSocialNormalizationTest.java
@@ -1,0 +1,29 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class ContactAndSocialNormalizationTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testContactUrlNoTrailingSlash() {
+        String html = "<html><body>"
+                + "<a href='https://example.com/contact/'>Contact</a>"
+                + "</body></html>";
+        String url = "https://example.com";
+        String contactUrl = parser.extractContactPageUrl(html, url);
+        assertThat(contactUrl, is("https://example.com/contact"));
+    }
+
+    @Test
+    public void testSocialLinkNoTrailingSlash() {
+        String html = "<html><body>"
+                + "<a href='https://facebook.com/example/'>FB</a>"
+                + "</body></html>";
+        String links = parser.extractSocialLinks(html);
+        assertThat(links, is("https://facebook.com/example"));
+    }
+}


### PR DESCRIPTION
## Summary
- trim trailing slash from contact page URLs
- test contact URL normalization and social link normalization

## Testing
- `mvn -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -q test` *(fails: BugFixAlaskaairmenOrgTest)*

------
https://chatgpt.com/codex/tasks/task_b_6856d2087e98832ba51c2084c95e54b9