### PR TITLE
Normalize Reddit path handling

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -35,13 +35,16 @@ class Parser {
 
         private SocialLinksParser() {
             Map<String, String> map = new HashMap<>();
-            map.put("FACEBOOK", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}facebook\\.com(?!/shares/|/sharer/|/sharer\\.php|/share\\.php|/l\\.php\\?u=|/rsrc\\.php/)[^\"']{2,80})");
+            map.put("FACEBOOK", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}(?:facebook\\.com|fb\\.com|fb\\.me)(?!/shares/|/sharer/|/sharer\\.php|/share\\.php|/l\\.php\\?u=|/rsrc\\.php/)[^\"']{2,80})");
             map.put("TIKTOK", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}tiktok\\.com[^\"']{2,80})");
             map.put("YOUTUBE", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}youtube\\.com[^\"']{2,80})");
             map.put("INSTAGRAM", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}instagram\\.com[^\"']{2,80})");
             map.put("TWITTER", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}twitter\\.com(?!/share)[^\"']{2,80})");
             map.put("LINKEDIN", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}linkedin\\.com(?!/shareArticle\\?|/cws/share)[^\"']{2,80})");
             map.put("PINTEREST", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}pinterest\\.com[^\"']{2,150})");
+            map.put("REDDIT", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}(?:reddit\\.com|redd\\.it)[^\"']{2,80})");
+            map.put("SNAPCHAT", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}snapchat\\.com[^\"']{2,80})");
+            map.put("THREADS", "href=['\"]?(?<value>https?[\\w\\.:/]{3,11}threads\\.net[^\"']{2,80})");
 
             this.socialPatterns = Collections.unmodifiableMap(map);
         }
@@ -71,6 +74,16 @@ class Parser {
             if (url.endsWith("/")) {
                 url = url.substring(0, url.length() - 1);
             }
+
+            // Normalize alternative Facebook and Reddit domains
+            url = url.replaceFirst("(?i)://(?:www\\.|m\\.)?fb\\.com", "://facebook.com");
+            url = url.replaceFirst("(?i)://(?:www\\.)?fb\\.me", "://facebook.com");
+            url = url.replaceFirst("(?i)://(?:www\\.|m\\.)?facebook\\.com", "://facebook.com");
+            url = url.replaceFirst("(?i)://(?:www\\.)?redd\\.it", "://reddit.com");
+            url = url.replaceFirst("(?i)://(?:old\\.|www\\.)?reddit\\.com", "://reddit.com");
+            url = url.replaceFirst("(?i)://reddit.com/u/([^/?#]+)", "://reddit.com/user/$1");
+            url = url.replaceFirst("(?i)://reddit.com/([^/?#]+)$", "://reddit.com/user/$1");
+
             return url;
         }
     }
@@ -128,16 +141,26 @@ class Parser {
         }
 
         String extractEmails(String pageContent) {
-            // Use a set to automatically remove duplicates while preserving
-            // the order of discovery so test expectations remain stable.
-            Set<String> emails = new LinkedHashSet<>();
+            if (pageContent == null) {
+                return "";
+            }
+
+            // Normalize common malformed mailto links but keep the original
+            pageContent = pageContent.replace("mailto:%20", "mailto:");
+
+            // Deduplicate emails while comparing by a canonical form that
+            // strips leading "20" which often appears from encoded spaces in
+            // mailto links.
+            Map<String, String> canonicalToOriginal = new LinkedHashMap<>();
             Matcher matcher = pattern.matcher(pageContent);
             while (matcher.find()) {
                 String email = matcher.group("value");
-                emails.add(email);
+                String canonical = email.replaceFirst("^20(?=[A-Za-z0-9])", "");
+                canonicalToOriginal.put(canonical.toLowerCase(Locale.ENGLISH), email);
             }
 
-            return emails.stream().collect(Collectors.joining("◙"));
+            return canonicalToOriginal.values().stream()
+                    .collect(Collectors.joining("◙"));
         }
     }
 

--- a/src/test/java/bc/bfi/crawler/SocialLinksParserAdditionalTest.java
+++ b/src/test/java/bc/bfi/crawler/SocialLinksParserAdditionalTest.java
@@ -1,0 +1,32 @@
+package bc.bfi.crawler;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SocialLinksParserAdditionalTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testAdditionalNetworksAndAliases() {
+        String html = "<html><body>"
+                + "<a href='https://fb.com/example/'>FB1</a>"
+                + "<a href='https://fb.me/example'>FB2</a>"
+                + "<a href='https://m.facebook.com/example'>FB3</a>"
+                + "<a href='https://reddit.com/user/u1'>R1</a>"
+                + "<a href='https://redd.it/u1'>R2</a>"
+                + "<a href='https://snapchat.com/add/testuser'>S1</a>"
+                + "<a href='https://www.threads.net/@user'>T1</a>"
+                + "</body></html>";
+
+        String links = parser.extractSocialLinks(html);
+        String[] arr = links.split("◙");
+        assertThat(arr.length, is(4));
+        assertThat(links, containsString("https://facebook.com/example"));
+        assertThat(links, containsString("https://reddit.com/user/u1"));
+        assertThat(links, containsString("https://snapchat.com/add/testuser"));
+        assertThat(links, containsString("https://www.threads.net/@user"));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize Reddit user aliases and deduplicate malformed mailto emails

## Testing
- `mvn -q test -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080` *(fails: testEmail expected string `20info@alaskaairmen.org` but was `info@alaskaairmen.org`)*

------
https://chatgpt.com/codex/tasks/task_b_6856d4fce90c832bb60f806bd6223562