### PR TITLE
Implement www normalization for social links

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -83,13 +83,13 @@ class Parser {
             if (a.equals(b)) {
                 return a;
             }
-            // Prefer non-www facebook variant
+            // Prefer www.facebook.com variant
             if (a.contains("facebook.com") && b.contains("facebook.com")) {
                 if (a.contains("www.facebook.com")) {
-                    return b;
+                    return a;
                 }
                 if (b.contains("www.facebook.com")) {
-                    return a;
+                    return b;
                 }
             }
             // Prefer https and www for twitter/x
@@ -122,6 +122,9 @@ class Parser {
             try {
                 URL parsed = new URL(url);
                 String host = parsed.getHost();
+                if (!host.toLowerCase(Locale.ENGLISH).startsWith("www.")) {
+                    host = "www." + host;
+                }
                 String path = parsed.getPath();
                 String query = parsed.getQuery();
                 String fragment = parsed.getRef();
@@ -146,17 +149,17 @@ class Parser {
                 url = url.substring(0, url.length() - 1);
             }
 
-            // Drop leading www. for most networks except Threads
-            url = url.replaceFirst("(?i)://www\\.(?!threads\\.net)", "://");
+            // Ensure leading www. for consistency across networks
+            url = url.replaceFirst("(?i)://(?!www\\.)", "://www.");
 
             // Normalize alternative Facebook and Reddit domains
-            url = url.replaceFirst("(?i)://(?:www\\.|m\\.)*fb\\.com", "://facebook.com");
-            url = url.replaceFirst("(?i)://(?:www\\.)*fb\\.me", "://facebook.com");
-            url = url.replaceFirst("(?i)://(?:www\\.|m\\.)*facebook\\.com", "://facebook.com");
-            url = url.replaceFirst("(?i)://(?:www\\.)*redd\\.it", "://reddit.com");
-            url = url.replaceFirst("(?i)://(?:old\\.|www\\.)*reddit\\.com", "://reddit.com");
-            url = url.replaceFirst("(?i)://(?:www\\.)?reddit\\.com/u/([^/?#]+)", "://reddit.com/user/$1");
-            url = url.replaceFirst("(?i)://(?:www\\.)?reddit\\.com/([^/?#]+)$", "://reddit.com/user/$1");
+            url = url.replaceFirst("(?i)://(?:www\\.|m\\.)*fb\\.com", "://www.facebook.com");
+            url = url.replaceFirst("(?i)://(?:www\\.)*fb\\.me", "://www.facebook.com");
+            url = url.replaceFirst("(?i)://(?:www\\.|m\\.)*facebook\\.com", "://www.facebook.com");
+            url = url.replaceFirst("(?i)://(?:www\\.)*redd\\.it", "://www.reddit.com");
+            url = url.replaceFirst("(?i)://(?:old\\.|www\\.)*reddit\\.com", "://www.reddit.com");
+            url = url.replaceFirst("(?i)://(?:www\\.)?reddit\\.com/u/([^/?#]+)", "://www.reddit.com/user/$1");
+            url = url.replaceFirst("(?i)://(?:www\\.)?reddit\\.com/([^/?#]+)$", "://www.reddit.com/user/$1");
 
             return url;
         }

--- a/src/test/java/bc/bfi/crawler/ContactAndSocialNormalizationTest.java
+++ b/src/test/java/bc/bfi/crawler/ContactAndSocialNormalizationTest.java
@@ -24,6 +24,6 @@ public class ContactAndSocialNormalizationTest {
                 + "<a href='https://facebook.com/example/'>FB</a>"
                 + "</body></html>";
         String links = parser.extractSocialLinks(html);
-        assertThat(links, is("https://facebook.com/example"));
+        assertThat(links, is("https://www.facebook.com/example"));
     }
 }

--- a/src/test/java/bc/bfi/crawler/SocialLinksDeduplicationTest.java
+++ b/src/test/java/bc/bfi/crawler/SocialLinksDeduplicationTest.java
@@ -34,8 +34,8 @@ public class SocialLinksDeduplicationTest {
         String[] parts = links.split("◙");
         assertThat(parts.length, is(2));
       
-        // facebook links are normalized without "www" prefix
-        assertThat(parts[0], is("https://facebook.com/example"));
-        assertThat(parts[1], is("https://twitter.com/user"));
+        // social links are normalized with "www" prefix
+        assertThat(parts[0], is("https://www.facebook.com/example"));
+        assertThat(parts[1], is("https://www.twitter.com/user"));
     }
 }

--- a/src/test/java/bc/bfi/crawler/SocialLinksParserAdditionalTest.java
+++ b/src/test/java/bc/bfi/crawler/SocialLinksParserAdditionalTest.java
@@ -24,9 +24,9 @@ public class SocialLinksParserAdditionalTest {
         String links = parser.extractSocialLinks(html);
         String[] arr = links.split("◙");
         assertThat(arr.length, is(4));
-        assertThat(links, containsString("https://facebook.com/example"));
-        assertThat(links, containsString("https://reddit.com/user/u1"));
-        assertThat(links, containsString("https://snapchat.com/add/testuser"));
+        assertThat(links, containsString("https://www.facebook.com/example"));
+        assertThat(links, containsString("https://www.reddit.com/user/u1"));
+        assertThat(links, containsString("https://www.snapchat.com/add/testuser"));
         assertThat(links, containsString("https://www.threads.net/@user"));
     }
 }


### PR DESCRIPTION
## Summary
- normalize parsed social links to always include `www` subdomain
- adjust selection logic to prefer `www.facebook.com`
- update tests for new canonical social link format

## Testing
- `mvn -q -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 test`

------
https://chatgpt.com/codex/tasks/task_b_6856e7e6b340832b8453d7bf8324ffdf