### PR TITLE
Fix email mailto prefix removal

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -226,8 +226,9 @@ class Parser {
                 return "";
             }
 
-            // Normalize common malformed mailto links but keep the original
-            pageContent = pageContent.replace("mailto:%20", "mailto:");
+            // Normalize common malformed mailto links and remove the scheme
+            pageContent = pageContent.replace("mailto:%20", "");
+            pageContent = pageContent.replaceAll("(?i)mailto:", "");
 
             // Deduplicate emails while comparing by a canonical form that
             // strips leading "20" which often appears from encoded spaces in

--- a/src/test/java/bc/bfi/crawler/MailtoRemovalTest.java
+++ b/src/test/java/bc/bfi/crawler/MailtoRemovalTest.java
@@ -1,0 +1,17 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class MailtoRemovalTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testMailtoPrefixIsRemoved() {
+        String html = "<html><body><a href='mailto:info@example.com'>Email</a></body></html>";
+        String emails = parser.extractEmail(html);
+        assertThat(emails, is("info@example.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- strip `mailto:` from page content before extracting email addresses
- add unit test ensuring `mailto:` prefixes are removed

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ...)*

------
https://chatgpt.com/codex/tasks/task_b_6856ea6ba6a8832b8ef681aa666eff61