### PR TITLE
Normalize contact page URL

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -367,9 +367,9 @@ class Parser {
             }
 
             contactPageUrl = contactPageUrl.trim();
-            if (contactPageUrl.endsWith("/")) {
-                contactPageUrl = contactPageUrl.substring(0, contactPageUrl.length() - 1);
-            }
+            // Remove a trailing slash both at the end of the URL and
+            // directly before a query or fragment part.
+            contactPageUrl = contactPageUrl.replaceFirst("/(?=[?#]|$)", "");
             return contactPageUrl;
         }
 

--- a/src/test/java/bc/bfi/crawler/ParseContactsPageSemiRealTest.java
+++ b/src/test/java/bc/bfi/crawler/ParseContactsPageSemiRealTest.java
@@ -656,21 +656,21 @@ public class ParseContactsPageSemiRealTest {
     public void testCassandraClare() throws IOException {
         String page = readString(Paths.get("src/test/resources/cassandraclare.com-home.html"), StandardCharsets.UTF_8);
         String contact = parser.extractContactPageUrl(page, "https://cassandraclare.com");
-        assertThat(contact, is("https://cassandraclare.com/contact/"));
+        assertThat(contact, is("https://cassandraclare.com/contact"));
     }
 
     @Test
     public void testPaulaBrackston() throws IOException {
         String page = readString(Paths.get("src/test/resources/paulabrackston.com-home.html"), StandardCharsets.UTF_8);
         String contact = parser.extractContactPageUrl(page, "https://www.paulabrackston.com");
-        assertThat(contact, is("https://www.paulabrackston.com/contact/"));
+        assertThat(contact, is("https://www.paulabrackston.com/contact"));
     }
 
     @Test
     public void testLisaKleypas() throws IOException {
         String page = readString(Paths.get("src/test/resources/lisakleypas.com-home.html"), StandardCharsets.UTF_8);
         String contact = parser.extractContactPageUrl(page, "https://lisakleypas.com");
-        assertThat(contact, is("https://lisakleypas.com/contact/"));
+        assertThat(contact, is("https://lisakleypas.com/contact"));
     }
 
     @Test
@@ -719,6 +719,6 @@ public class ParseContactsPageSemiRealTest {
     public void testHannahHowell() throws IOException {
         String page = readString(Paths.get("src/test/resources/hannahhowell.com-home.html"), StandardCharsets.UTF_8);
         String contact = parser.extractContactPageUrl(page, "https://hannahhowell.com");
-        assertThat(contact, is("https://hannahhowell.com/contact/"));
+        assertThat(contact, is("https://hannahhowell.com/contact"));
     }
 }


### PR DESCRIPTION
## Summary
- trim trailing slash from contact page URLs even before query/fragment
- expect URLs without trailing slash in ParseContactsPageSemiRealTest

## Testing
- `mvn -q -Dtest=ParseContactsPageSemiRealTest test` *(fails: Non-resolvable import POM org.glassfish.jersey:jersey-bom:pom:2.27)*

------
https://chatgpt.com/codex/tasks/task_b_685949d94ac4832b92a97c0d47b2ea36