### PR TITLE
Update contact page parsing logic

### DIFF
--- a/src/main/java/bc/bfi/crawler/Main.java
+++ b/src/main/java/bc/bfi/crawler/Main.java
@@ -45,17 +45,18 @@ public class Main {
             String contactUrl = parser.extractContactPageUrl(page, url);
             if (!contactUrl.isEmpty()) {
                 String contactPage = downloader.load(contactUrl);
-                if (contactFormDetector.hasContactFormFromHtml(contactPage)) {
+                boolean hasForm = contactFormDetector.hasContactFormFromHtml(contactPage);
+                if (hasForm) {
                     website.setContactFormUrl(contactUrl);
-                    if (website.getEmails().isEmpty()) {
-                        website.setEmails(parser.extractEmail(contactPage));
-                    }
-                    if (website.getPhones().isEmpty()) {
-                        website.setPhones(parser.extractPhone(contactPage));
-                    }
-                    if (website.getSocialLinks().isEmpty()) {
-                        website.setSocialLinks(parser.extractSocialLinks(contactPage));
-                    }
+                }
+                if (website.getEmails().isEmpty()) {
+                    website.setEmails(parser.extractEmail(contactPage));
+                }
+                if (website.getPhones().isEmpty()) {
+                    website.setPhones(parser.extractPhone(contactPage));
+                }
+                if (website.getSocialLinks().isEmpty()) {
+                    website.setSocialLinks(parser.extractSocialLinks(contactPage));
                 }
             }
 

--- a/src/test/java/bc/bfi/crawler/MainContactPageFilterTest.java
+++ b/src/test/java/bc/bfi/crawler/MainContactPageFilterTest.java
@@ -29,6 +29,9 @@ public class MainContactPageFilterTest {
                 .thenReturn("https://example.com/contact");
         when(downloader.load("https://example.com/contact")).thenReturn("contact");
         when(detector.hasContactFormFromHtml("contact")).thenReturn(false);
+        when(parser.extractEmail("contact")).thenReturn("e");
+        when(parser.extractPhone("contact")).thenReturn("p");
+        when(parser.extractSocialLinks("contact")).thenReturn("s");
 
         Main main = new Main(urls, storage, downloader, parser, detector);
         java.lang.reflect.Method m = Main.class.getDeclaredMethod("go");
@@ -39,6 +42,9 @@ public class MainContactPageFilterTest {
         verify(storage).append(captor.capture());
         Website site = captor.getValue();
         assertThat(site.getContactFormUrl(), is(""));
+        assertThat(site.getEmails(), is("e"));
+        assertThat(site.getPhones(), is("p"));
+        assertThat(site.getSocialLinks(), is("s"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update contact page scraping to parse contact info even without a form
- adjust tests for new behavior

## Testing
- `mvn -q test` *(fails: ParserTest and semi‑real tests)*

------
https://chatgpt.com/codex/tasks/task_b_686682a58a50832b934aa7eff0d5aab2