### PR TITLE
Remove Sentry emails from parser

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -302,6 +302,10 @@ class Parser {
                 if (lower.matches(".*@[0-9]+x\\.(png|jpe?g|gif|bmp|svg|webp)$")) {
                     continue;
                 }
+                if (lower.endsWith("@sentry.wixpress.com")
+                        || lower.endsWith("@sentry-next.wixpress.com")) {
+                    continue;
+                }
                 canonicalToOriginal.put(lower, email);
             }
 

--- a/src/test/java/bc/bfi/crawler/SentryEmailRemovalTest.java
+++ b/src/test/java/bc/bfi/crawler/SentryEmailRemovalTest.java
@@ -1,0 +1,17 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class SentryEmailRemovalTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testSentryEmailsAreIgnored() {
+        String html = "contact@mail.com 605a7baede844d278b89dc95ae0a9123@sentry-next.wixpress.com ed436f5053144538958ad06a5005e99a@sentry.wixpress.com";
+        String emails = parser.extractEmail(html);
+        assertThat(emails, is("contact@mail.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- filter Sentry service emails from parser results
- add unit test verifying Sentry emails are ignored

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6866b705e6b8832bad4e2bfe32bc9073