### PR TITLE
Fix HTTP 307 redirect handling

### DIFF
--- a/src/main/java/bc/bfi/crawler/Downloader.java
+++ b/src/main/java/bc/bfi/crawler/Downloader.java
@@ -131,7 +131,9 @@ class Downloader {
         if (status != HttpURLConnection.HTTP_OK) {
             if (status == HttpURLConnection.HTTP_MOVED_TEMP
                     || status == HttpURLConnection.HTTP_MOVED_PERM
-                    || status == HttpURLConnection.HTTP_SEE_OTHER) {
+                    || status == HttpURLConnection.HTTP_SEE_OTHER
+                    || status == 307 /* HTTP_TEMP_REDIRECT */
+                    || status == 308 /* HTTP_PERM_REDIRECT */) {
                 redirect = true;
             }
         }

--- a/src/test/java/bc/bfi/crawler/DownloaderRedirectTest.java
+++ b/src/test/java/bc/bfi/crawler/DownloaderRedirectTest.java
@@ -1,0 +1,41 @@
+package bc.bfi.crawler;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class DownloaderRedirectTest {
+
+    @Test
+    public void handlesHttpTempRedirect() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = server.getAddress().getPort();
+        server.createContext("/", (HttpExchange exchange) -> {
+            exchange.getResponseHeaders().add("Location", "http://localhost:" + port + "/target");
+            exchange.sendResponseHeaders(307, -1);
+            exchange.close();
+        });
+        server.createContext("/target", (HttpExchange exchange) -> {
+            byte[] body = "redirected".getBytes("UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        try {
+            Downloader downloader = new Downloader();
+            Method m = Downloader.class.getDeclaredMethod("loadWithDirectConnection", String.class);
+            m.setAccessible(true);
+            String content = (String) m.invoke(downloader, "http://localhost:" + port + "/");
+            assertThat(content, containsString("redirected"));
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- follow HTTP 307/308 responses when downloading pages
- add a unit test proving that Downloader handles HTTP 307 redirects

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6878229a980c832ba54f3c2bdf589aad