### PR TITLE
Update ContactFormDetector to handle hyphenated name input

### DIFF
--- a/src/main/java/bc/bfi/crawler/ContactFormDetector.java
+++ b/src/main/java/bc/bfi/crawler/ContactFormDetector.java
@@ -57,7 +57,11 @@ class ContactFormDetector {
     }
 
     private boolean hasNameField(Element form) {
-        return !form.select("input[name~=(?i)name], input[id~=(?i)name], input[class~=(?i)name], input[placeholder~=(?i)name], label:matchesOwn((?i)name)").isEmpty();
+        return !form.select(
+                "input[name~=(?i)name], input[name^=name i], input[name*=name i], " +
+                "input[id~=(?i)name], input[class~=(?i)name], " +
+                "input[placeholder~=(?i)name], label:matchesOwn((?i)name)")
+                .isEmpty();
     }
 
     private boolean hasEmailField(Element form) {

--- a/src/test/java/bc/bfi/crawler/ContactFormDetectorTest.java
+++ b/src/test/java/bc/bfi/crawler/ContactFormDetectorTest.java
@@ -49,4 +49,16 @@ public class ContactFormDetectorTest {
         ContactFormDetector detector = new ContactFormDetector();
         assertThat(detector.hasContactFormFromHtml(html), is(true));
     }
+
+    @Test
+    public void testDetectsNameWithHyphen() {
+        String html = "<form>" +
+                "<input name='name-*'>" +
+                "<input name='email' type='email'>" +
+                "<textarea placeholder='Message'></textarea>" +
+                "<button type='submit'>Send</button>" +
+                "</form>";
+        ContactFormDetector detector = new ContactFormDetector();
+        assertThat(detector.hasContactFormFromHtml(html), is(true));
+    }
 }


### PR DESCRIPTION
## Summary
- enhance contact form detection by matching name fields that start with or contain `name`
- add unit test covering input fields like `name-*`

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6878c4823d60832b82f2ba48a61bd105