### PR TITLE
Improve contact form detection

### DIFF
--- a/src/main/java/bc/bfi/crawler/ContactFormDetector.java
+++ b/src/main/java/bc/bfi/crawler/ContactFormDetector.java
@@ -65,7 +65,12 @@ class ContactFormDetector {
     }
 
     private boolean hasEmailField(Element form) {
-        return !form.select("input[type=email], input[name~=(?i)mail], input[id~=(?i)mail], input[class~=(?i)mail], input[placeholder~=(?i)mail]").isEmpty();
+        return !form.select(
+                "input[type=email], " +
+                "input[name~=(?i)mail], input[id~=(?i)mail], " +
+                "input[class~=(?i)mail], input[placeholder~=(?i)mail], " +
+                "input[name*=email i]")
+                .isEmpty();
     }
 
     private boolean hasMessageField(Element form) {

--- a/src/test/java/bc/bfi/crawler/ContactFormDetectorTest.java
+++ b/src/test/java/bc/bfi/crawler/ContactFormDetectorTest.java
@@ -61,4 +61,21 @@ public class ContactFormDetectorTest {
         ContactFormDetector detector = new ContactFormDetector();
         assertThat(detector.hasContactFormFromHtml(html), is(true));
     }
+    @Test
+    public void testDetectsWpCf7ContactForm() {
+        String html = "<form action='/contact-debra/#wpcf7-f3091-p80-o1' method='post' class='wpcf7-form init' novalidate='novalidate'>" +
+                "<div style='display: none;'><input type='hidden' name='_wpcf7' value='3091' />" +
+                "<input type='hidden' name='_wpcf7_version' value='6.0.5' />" +
+                "<input type='hidden' name='_wpcf7_locale' value='en_US' />" +
+                "<input type='hidden' name='_wpcf7_unit_tag' value='wpcf7-f3091-p80-o1' />" +
+                "<input type='hidden' name='_wpcf7_container_post' value='80' />" +
+                "</div>" +
+                "<p><span class='wpcf7-form-control-wrap' data-name='your-name'><input type='text' name='your-name'></span></p>" +
+                "<p><span class='wpcf7-form-control-wrap' data-name='your-email'><input type='email' name='your-email'></span></p>" +
+                "<p><span class='wpcf7-form-control-wrap' data-name='your-message'><textarea name='your-message'></textarea></span></p>" +
+                "<p><input type='submit' value='Submit' class='wpcf7-form-control wpcf7-submit'></p>" +
+                "</form>";
+        ContactFormDetector detector = new ContactFormDetector();
+        assertThat(detector.hasContactFormFromHtml(html), is(true));
+    }
 }


### PR DESCRIPTION
## Summary
- improve email field recognition in `ContactFormDetector`
- verify recognition of Contact Form 7 snippet

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6878c82ace84832b8f26e4e35a2ad5f5