### PR TITLE
Add MESSAGE field to output

### DIFF
--- a/src/main/java/bc/bfi/crawler/Downloader.java
+++ b/src/main/java/bc/bfi/crawler/Downloader.java
@@ -37,9 +37,15 @@ class Downloader {
     };
 
     private String cookies = "";
+    private boolean scrapeNinjaUsed = false;
+
+    boolean wasScrapeNinjaUsed() {
+        return scrapeNinjaUsed;
+    }
 
     String loadBaseUrl(final String url) {
         String page = "";
+        scrapeNinjaUsed = false;
 
         String baseUrl = Utils.extractBaseUrl(url);
 
@@ -51,6 +57,7 @@ class Downloader {
 
         if (page.isEmpty()) {
             System.out.println("Direct download failed. Try to download " + baseUrl + " with ScrapeNinja.");
+            scrapeNinjaUsed = true;
             try {
                 page = loadWithScrapeNinja(baseUrl);
             } catch (IOException ex) {
@@ -67,6 +74,7 @@ class Downloader {
 
     String load(final String url) {
         String page = "";
+        scrapeNinjaUsed = false;
 
         try {
             page = loadWithDirectConnection(url);
@@ -76,6 +84,7 @@ class Downloader {
 
         if (page.isEmpty()) {
             System.out.println("Direct download failed. Try to download " + url + " with ScrapeNinja.");
+            scrapeNinjaUsed = true;
             try {
                 page = loadWithScrapeNinja(url);
             } catch (IOException ex) {

--- a/src/main/java/bc/bfi/crawler/Main.java
+++ b/src/main/java/bc/bfi/crawler/Main.java
@@ -36,8 +36,16 @@ public class Main {
             System.out.println("Scrape website: " + url);
 
             String page = downloader.loadBaseUrl(url);
-
             Website website = new Website(url);
+
+            if (downloader.wasScrapeNinjaUsed()) {
+                website.addMessage("Direct download failed; used ScrapeNinja");
+            }
+
+            String text = org.jsoup.Jsoup.parse(page).text().trim();
+            if (text.length() < 1000) {
+                website.addMessage("Website most likely rendered with JavaScript");
+            }
             website.setEmails(parser.extractEmail(page));
             website.setPhones(parser.extractPhone(page));
             website.setSocialLinks(parser.extractSocialLinks(page));
@@ -45,6 +53,9 @@ public class Main {
             String contactUrl = parser.extractContactPageUrl(page, url);
             if (!contactUrl.isEmpty()) {
                 String contactPage = downloader.load(contactUrl);
+                if (downloader.wasScrapeNinjaUsed()) {
+                    website.addMessage("Direct download failed; used ScrapeNinja");
+                }
                 boolean hasForm = contactFormDetector.hasContactFormFromHtml(contactPage);
                 if (hasForm) {
                     website.setContactFormUrl(contactUrl);

--- a/src/main/java/bc/bfi/crawler/Storage.java
+++ b/src/main/java/bc/bfi/crawler/Storage.java
@@ -24,7 +24,8 @@ class Storage {
         "EMAILS",
         "PHONES",
         "CONTACT_FORM_URL",
-        "SOCIAL_LINKS"
+        "SOCIAL_LINKS",
+        "MESSAGE"
     };
 
     Storage() {
@@ -63,6 +64,7 @@ class Storage {
         record.add(website.getPhones());
         record.add(website.getContactFormUrl());
         record.add(website.getSocialLinks());
+        record.add(website.getMessage());
 
         Path path = Paths.get(STORAGE_FILE);
         try (Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {

--- a/src/main/java/bc/bfi/crawler/Website.java
+++ b/src/main/java/bc/bfi/crawler/Website.java
@@ -10,6 +10,7 @@ class Website {
     private String phones = "";
     private String contactFormUrl = "";
     private String socialLinks = "";
+    private String message = "";
 
     public Website(String domain) {
         this.domain = domain;
@@ -51,12 +52,28 @@ class Website {
         return domain;
     }
 
+    String getMessage() {
+        return message;
+    }
+
+    void addMessage(String msg) {
+        if (msg == null || msg.isEmpty()) {
+            return;
+        }
+        if (message.isEmpty()) {
+            message = msg;
+        } else if (!message.contains(msg)) {
+            message += "; " + msg;
+        }
+    }
+
     void print() {
         System.out.println("Domain: " + this.domain);
         System.out.println("Contact form: " + this.contactFormUrl);
         System.out.println("E-mails: " + this.emails);
         System.out.println("Phones: " + this.phones);
         System.out.println("Social links: " + this.socialLinks);
+        System.out.println("Message: " + this.message);
     }
 
 }

--- a/src/test/java/bc/bfi/crawler/MessageFieldTest.java
+++ b/src/test/java/bc/bfi/crawler/MessageFieldTest.java
@@ -1,0 +1,75 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class MessageFieldTest {
+
+    @Test
+    public void addsMessageWhenScrapeNinjaUsed() throws Exception {
+        Path urls = Files.createTempFile("urls", ".txt");
+        Files.write(urls, Collections.singletonList("https://example.com"));
+
+        Downloader downloader = mock(Downloader.class);
+        Parser parser = mock(Parser.class);
+        ContactFormDetector detector = mock(ContactFormDetector.class);
+        Storage storage = mock(Storage.class);
+
+        String longPage = "<html><body>" + new String(new char[1500]).replace('\0', 'a') + "</body></html>";
+        when(downloader.loadBaseUrl("https://example.com")).thenReturn(longPage);
+        when(downloader.wasScrapeNinjaUsed()).thenReturn(true);
+        when(parser.extractEmail(longPage)).thenReturn("");
+        when(parser.extractPhone(longPage)).thenReturn("");
+        when(parser.extractSocialLinks(longPage)).thenReturn("");
+        when(parser.extractContactPageUrl(longPage, "https://example.com")).thenReturn("");
+
+        Main main = new Main(urls, storage, downloader, parser, detector);
+        Method m = Main.class.getDeclaredMethod("go");
+        m.setAccessible(true);
+        m.invoke(main);
+
+        ArgumentCaptor<Website> captor = ArgumentCaptor.forClass(Website.class);
+        verify(storage).append(captor.capture());
+        Website site = captor.getValue();
+        assertThat(site.getMessage(), is("Direct download failed; used ScrapeNinja"));
+    }
+
+    @Test
+    public void addsMessageWhenPageLooksJsRendered() throws Exception {
+        Path urls = Files.createTempFile("urls", ".txt");
+        Files.write(urls, Collections.singletonList("https://example.com"));
+
+        Downloader downloader = mock(Downloader.class);
+        Parser parser = mock(Parser.class);
+        ContactFormDetector detector = mock(ContactFormDetector.class);
+        Storage storage = mock(Storage.class);
+
+        String shortPage = "<html><body>short</body></html>";
+        when(downloader.loadBaseUrl("https://example.com")).thenReturn(shortPage);
+        when(downloader.wasScrapeNinjaUsed()).thenReturn(false);
+        when(parser.extractEmail(shortPage)).thenReturn("");
+        when(parser.extractPhone(shortPage)).thenReturn("");
+        when(parser.extractSocialLinks(shortPage)).thenReturn("");
+        when(parser.extractContactPageUrl(shortPage, "https://example.com")).thenReturn("");
+
+        Main main = new Main(urls, storage, downloader, parser, detector);
+        Method m = Main.class.getDeclaredMethod("go");
+        m.setAccessible(true);
+        m.invoke(main);
+
+        ArgumentCaptor<Website> captor = ArgumentCaptor.forClass(Website.class);
+        verify(storage).append(captor.capture());
+        Website site = captor.getValue();
+        assertThat(site.getMessage(), is("Website most likely rendered with JavaScript"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `message` field to `Website`
- store MESSAGE column in `Storage`
- track ScrapeNinja usage in `Downloader`
- mark JS-rendered pages in `Main`
- test new MESSAGE logic

## Testing
- `mvn -q test` *(fails: There are test failures)*

------
https://chatgpt.com/codex/tasks/task_b_687a8f9acf4c832bb26aaf3264e6a347