### PR TITLE
Strip phone numbers from HTML

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -4,6 +4,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.*;
 import java.util.*;
+import org.jsoup.Jsoup;
 import java.util.stream.Collectors;
 
 class Parser {
@@ -226,6 +227,16 @@ class Parser {
         }
 
         String extractPhones(String pageContent) {
+            if (pageContent == null) {
+                return "";
+            }
+
+            try {
+                pageContent = Jsoup.parse(pageContent).text();
+            } catch (Exception ex) {
+                // ignore parsing issues and fallback to original content
+            }
+
             List<String> phoneNumbers = new ArrayList<>();
             Matcher matcher = pattern.matcher(pageContent);
 

--- a/src/test/java/bc/bfi/crawler/PhoneHtmlCodeExclusionTest.java
+++ b/src/test/java/bc/bfi/crawler/PhoneHtmlCodeExclusionTest.java
@@ -1,0 +1,32 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PhoneHtmlCodeExclusionTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testPhoneInScriptIgnored() {
+        String html = "<html><head><script>var tel='123-456-7890';</script></head><body></body></html>";
+        String phones = parser.extractPhone(html);
+        assertThat(phones, is(""));
+    }
+
+    @Test
+    public void testPhoneInStyleIgnored() {
+        String html = "<html><head><style>.x{content:'123-456-7890';}</style></head><body></body></html>";
+        String phones = parser.extractPhone(html);
+        assertThat(phones, is(""));
+    }
+
+    @Test
+    public void testPhoneInAttributeIgnored() {
+        String html = "<div data-phone='123-456-7890'>Call</div>";
+        String phones = parser.extractPhone(html);
+        assertThat(phones, is(""));
+    }
+}


### PR DESCRIPTION
## Summary
- ignore HTML markup when extracting phone numbers
- add tests ensuring phones in HTML/JS/CSS are skipped

## Testing
- `mvn -q test` *(fails: There are test failures)*

------
https://chatgpt.com/codex/tasks/task_b_687a8f063174832b9c65881639fe5165