### PR TITLE
Add email domain exclusions

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -286,6 +286,13 @@ class Parser {
 
         private static final String emailRegex
                 = "(\\b|^)(?<value>[A-Za-z0-9\\-_]+[A-Za-z0-9\\-_.]*@[A-Za-z0-9.:\\-]+\\.[A-Za-z]{2,12})(\\b|$)";
+        private static final List<String> excludedDomains = Arrays.asList(
+                "sentry.wixpress.com",
+                "sentry-next.wixpress.com",
+                "domain.com",
+                "sentry.io",
+                "myftpupload.com"
+        );
         private final Pattern pattern;
 
         EmailParser() {
@@ -313,8 +320,15 @@ class Parser {
                 if (lower.matches(".*@[0-9]+x\\.(png|jpe?g|gif|bmp|svg|webp)$")) {
                     continue;
                 }
-                if (lower.endsWith("@sentry.wixpress.com")
-                        || lower.endsWith("@sentry-next.wixpress.com")) {
+                String domain = lower.substring(lower.indexOf('@') + 1);
+                boolean skip = false;
+                for (String excluded : excludedDomains) {
+                    if (domain.endsWith(excluded)) {
+                        skip = true;
+                        break;
+                    }
+                }
+                if (skip) {
                     continue;
                 }
                 canonicalToOriginal.put(lower, email);

--- a/src/test/java/bc/bfi/crawler/DomainExclusionTest.java
+++ b/src/test/java/bc/bfi/crawler/DomainExclusionTest.java
@@ -1,0 +1,18 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class DomainExclusionTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testExcludedDomainsAreIgnored() {
+        String html = "info@domain.com user@sentry.io admin@myftpupload.com good@example.com";
+        String emails = parser.extractEmail(html);
+        assertThat(emails, is("good@example.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- ignore emails from common spam domains
- add a unit test for domain exclusions

## Testing
- `mvn -q test` *(fails: `'dependencies.dependency.version' ... network is unreachable`)*

------
https://chatgpt.com/codex/tasks/task_b_6883a2e026e4832b88d9ed4830c89524