### PR TITLE
Handle SSL errors with HTTP fallback

### DIFF
--- a/src/main/java/bc/bfi/crawler/Downloader.java
+++ b/src/main/java/bc/bfi/crawler/Downloader.java
@@ -53,6 +53,14 @@ class Downloader {
             page = loadWithDirectConnection(baseUrl);
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Cannot download " + baseUrl + " with direct connection.", ex);
+            if (baseUrl.startsWith("https://") && isSslException(ex)) {
+                String httpUrl = baseUrl.replaceFirst("^https://", "http://");
+                try {
+                    page = loadWithDirectConnection(httpUrl);
+                } catch (IOException ex2) {
+                    LOGGER.log(Level.SEVERE, "Cannot download " + httpUrl + " with direct connection.", ex2);
+                }
+            }
         }
 
         if (page.isEmpty()) {
@@ -80,6 +88,14 @@ class Downloader {
             page = loadWithDirectConnection(url);
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Cannot download " + url + " with direct connection.", ex);
+            if (url.startsWith("https://") && isSslException(ex)) {
+                String httpUrl = url.replaceFirst("^https://", "http://");
+                try {
+                    page = loadWithDirectConnection(httpUrl);
+                } catch (IOException ex2) {
+                    LOGGER.log(Level.SEVERE, "Cannot download " + httpUrl + " with direct connection.", ex2);
+                }
+            }
         }
 
         if (page.isEmpty()) {
@@ -200,5 +216,16 @@ class Downloader {
             baos.write(buffer, 0, len);
         }
         return baos.toByteArray();
+    }
+
+    private boolean isSslException(IOException ex) {
+        Throwable t = ex;
+        while (t != null) {
+            if (t instanceof javax.net.ssl.SSLException) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 }

--- a/src/test/java/bc/bfi/crawler/DownloaderSslFallbackTest.java
+++ b/src/test/java/bc/bfi/crawler/DownloaderSslFallbackTest.java
@@ -1,0 +1,35 @@
+package bc.bfi.crawler;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class DownloaderSslFallbackTest {
+
+    @Test
+    public void fallsBackToHttpWhenHttpsFails() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = server.getAddress().getPort();
+        server.createContext("/", (HttpExchange exchange) -> {
+            byte[] body = "plain-http".getBytes("UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        try {
+            Downloader downloader = new Downloader();
+            String content = downloader.load("https://localhost:" + port + "/");
+            assertThat(content, containsString("plain-http"));
+            assertThat(downloader.wasScrapeNinjaUsed(), is(false));
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- retry with HTTP when HTTPS fails with SSL issues before ScrapeNinja
- add unit test for HTTP fallback

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM org.glassfish.jersey:jersey-bom due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68844c4b5518832b8b37f65f7a07149e