### PR TITLE
Handle HTTP 403 redirects

### DIFF
--- a/src/test/java/bc/bfi/crawler/DownloaderForbiddenRedirectTest.java
+++ b/src/test/java/bc/bfi/crawler/DownloaderForbiddenRedirectTest.java
@@ -1,0 +1,41 @@
+package bc.bfi.crawler;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class DownloaderForbiddenRedirectTest {
+
+    @Test
+    public void handlesHttpForbiddenRedirect() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = server.getAddress().getPort();
+        server.createContext("/", (HttpExchange exchange) -> {
+            exchange.getResponseHeaders().add("Location", "http://localhost:" + port + "/target");
+            exchange.sendResponseHeaders(403, -1);
+            exchange.close();
+        });
+        server.createContext("/target", (HttpExchange exchange) -> {
+            byte[] body = "redirected".getBytes("UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        try {
+            Downloader downloader = new Downloader();
+            Method m = Downloader.class.getDeclaredMethod("loadWithDirectConnection", String.class);
+            m.setAccessible(true);
+            String content = (String) m.invoke(downloader, "http://localhost:" + port + "/");
+            assertThat(content, containsString("redirected"));
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle 403 status code with Location header in `Downloader`
- recursively follow redirects
- add unit test for 403 redirects

## Testing
- `mvn -q test` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688452e57a50832b942e26d571bd802d