### PR TITLE
Fix phone parser ISBN false positives

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -220,6 +220,7 @@ class Parser {
 
         private static final String phoneRegex
                 = "(?<!\\d)(?<value>(?:\\+?1[\\s.-]*)?\\(?\\d{3}\\)?[\\s.-]*\\d{3}[\\s.-]*\\d{4}|\\d{10,11}|\\d{2}-\\d{7})(?!\\d)";
+        private static final int ISBN_PREFIX_RANGE = 20;
         // Old regexp "(?<!\\d)(?<value>(?:\\+?1[\\s.-]*)?\\(?\\d{3}\\)?[\\s.-]*\\d{3}[\\s.-]*\\d{4}|\\d{10,11}|\\d{2}-\\d{7})(?!\\d)"
         private final Pattern pattern;
 
@@ -242,6 +243,13 @@ class Parser {
             Matcher matcher = pattern.matcher(pageContent);
 
             while (matcher.find()) {
+                int start = matcher.start();
+                int prefixStart = Math.max(0, start - ISBN_PREFIX_RANGE);
+                String prefix = pageContent.substring(prefixStart, start).toLowerCase();
+                if (prefix.contains("isbn")) {
+                    continue;
+                }
+
                 String phone = matcher.group("value");
                 phoneNumbers.add(phone);
             }

--- a/src/test/java/bc/bfi/crawler/PhoneIsbnExclusionTest.java
+++ b/src/test/java/bc/bfi/crawler/PhoneIsbnExclusionTest.java
@@ -1,0 +1,32 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PhoneIsbnExclusionTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testIsbnNumbersAreIgnored() {
+        String text = "Avon:  2/18/2020\n" +
+                "ISBN: 978-0062371942\n" +
+                "Avon:  2/19/2019\n" +
+                "ISBN: 9780062371898\n" +
+                "Avon:  2/27/2018\n" +
+                "ISBN: 9780062371898\n" +
+                "Avon:   2/2017\n" +
+                "ISBN: 978-0062371874\n" +
+                "Avon: 5/31/2016\n" +
+                "ISBN-13: 9780062371850\n" +
+                "Avon:  10/27/2015\n" +
+                "ISBN-13: 9780062371812\n" +
+                "Avon:  7/27/2021\n" +
+                "ISBN: 978-0062371966";
+
+        String phones = parser.extractPhone(text);
+        assertThat(phones, is(""));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid phone extraction on ISBN fields
- test phone parser ignores ISBN numbers

## Testing
- `mvn -q test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_68845ea67470832ba58a7d7fdb7d2d8e