### PR TITLE
Fix SocialLinks root domain collection

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -118,6 +118,15 @@ class Parser {
         }
 
         private boolean isProfileUrl(String url) {
+            try {
+                URL parsed = new URL(url);
+                String path = parsed.getPath();
+                if (path == null || path.isEmpty() || "/".equals(path)) {
+                    return false;
+                }
+            } catch (MalformedURLException ex) {
+                // ignore malformed urls
+            }
             String lower = url.toLowerCase(Locale.ENGLISH);
             if (lower.contains("facebook.com")) {
                 if (lower.matches("https?://www\\.facebook\\.com/(?:groups|events)/.*")) {

--- a/src/test/java/bc/bfi/crawler/SocialLinksDomainRootSkipTest.java
+++ b/src/test/java/bc/bfi/crawler/SocialLinksDomainRootSkipTest.java
@@ -1,0 +1,24 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class SocialLinksDomainRootSkipTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testDomainOnlyLinksAreIgnored() {
+        String html = "<html><body>"
+                + "<a href='https://www.facebook.com'>F</a>"
+                + "<a href='https://twitter.com/'>T</a>"
+                + "<a href='https://www.instagram.com'>I</a>"
+                + "<a href='https://www.linkedin.com'>L</a>"
+                + "</body></html>";
+
+        String links = parser.extractSocialLinks(html);
+        assertThat(links, is(""));
+    }
+}


### PR DESCRIPTION
## Summary
- skip social links that point only to the root domain
- test that plain social domains are ignored

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688462718cf4832b856c771788dad8ed