### PR TITLE
Add Pinterest explore profile support

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -150,7 +150,7 @@ class Parser {
                 }
             }
             if (lower.contains("pinterest.com")) {
-                if (lower.matches("https?://www\\.pinterest\\.com/(?:pin|explore|search)/.*")) {
+                if (lower.matches("https?://www\\.pinterest\\.com/(?:pin|search)/.*")) {
                     return false;
                 }
             }

--- a/src/test/java/bc/bfi/crawler/PinterestExploreProfileTest.java
+++ b/src/test/java/bc/bfi/crawler/PinterestExploreProfileTest.java
@@ -1,0 +1,21 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PinterestExploreProfileTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void collectsExploreProfiles() {
+        String html = "<html><body>"
+                + "<a href='https://www.pinterest.com/explore/nora-roberts'>P</a>"
+                + "</body></html>";
+
+        String links = parser.extractSocialLinks(html);
+        assertThat(links, is("https://www.pinterest.com/explore/nora-roberts"));
+    }
+}


### PR DESCRIPTION
## Summary
- support Pinterest "explore" profile links in SocialLinksParser
- add unit test for Pinterest explore profile extraction

## Testing
- `mvn test` *(fails: The build could not read project due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688728a4d250832bbec5ab0e91bd6a1f