### PR TITLE
Add contact form field count check

### DIFF
--- a/src/main/java/bc/bfi/crawler/ContactFormDetector.java
+++ b/src/main/java/bc/bfi/crawler/ContactFormDetector.java
@@ -45,7 +45,8 @@ class ContactFormDetector {
 
     private boolean isContactForm(Element form) {
         if (isSearchForm(form) || isSignInForm(form) || isSignUpForm(form)
-                || isDonateForm(form) || isSubscriptionForm(form)) {
+                || isDonateForm(form) || isSubscriptionForm(form)
+                || !isHasAtLeast2Fields(form)) {
             return false;
         }
         int score = 0;
@@ -128,5 +129,10 @@ class ContactFormDetector {
                 "button:matchesOwn((?i)sign.?up|register)"
         ).isEmpty();
         return hasPassword && hasSignup;
+    }
+
+    private boolean isHasAtLeast2Fields(Element form) {
+        Elements fields = form.select("input:not([type=hidden]), textarea");
+        return fields.size() >= 2;
     }
 }

--- a/src/test/java/bc/bfi/crawler/ContactFormDetectorTest.java
+++ b/src/test/java/bc/bfi/crawler/ContactFormDetectorTest.java
@@ -71,6 +71,13 @@ public class ContactFormDetectorTest {
     }
 
     @Test
+    public void testIgnoresFormWithSingleField() {
+        String html = "<form><input name='email'></form>";
+        ContactFormDetector detector = new ContactFormDetector();
+        assertThat(detector.hasContactFormFromHtml(html), is(false));
+    }
+
+    @Test
     public void testIgnoresSignInFormByButton() {
         String html = "<form>" +
                 "<input type='text' name='user'>" +


### PR DESCRIPTION
## Summary
- improve contact form detection by ensuring a form has at least two fields
- implement `isHasAtLeast2Fields` helper
- cover the new behaviour with unit test

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6887494db098832b8354d4b50b6a3b29