### PR TITLE
Add ScrapeNinja retry on Client Challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The program prints the discovered information to the console and appends it to `
 - **urls-authors-verified.txt** and **urls-irs-verified.txt** – sample alternative URL lists.
 
 The crawler will automatically attempt a direct HTTP request first. If it fails, it falls back to the [ScrapeNinja](https://scrapeninja.p.rapidapi.com/) API as implemented in `Downloader`.
+If a page responds with `<title>Client Challenge</title>`, the crawler also retries that request using ScrapeNinja.
 
 ## Testing
 

--- a/src/main/java/bc/bfi/crawler/Downloader.java
+++ b/src/main/java/bc/bfi/crawler/Downloader.java
@@ -63,6 +63,16 @@ class Downloader {
             }
         }
 
+        if (!page.isEmpty() && isClientChallenge(page)) {
+            System.out.println("Client Challenge detected. Try to download " + baseUrl + " with ScrapeNinja.");
+            scrapeNinjaUsed = true;
+            try {
+                page = loadWithScrapeNinja(baseUrl);
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, "Cannot download " + baseUrl + " with ScrapeNinja.", ex);
+            }
+        }
+
         if (page.isEmpty()) {
             System.out.println("Direct download failed. Try to download " + baseUrl + " with ScrapeNinja.");
             scrapeNinjaUsed = true;
@@ -95,6 +105,16 @@ class Downloader {
                 } catch (IOException ex2) {
                     LOGGER.log(Level.SEVERE, "Cannot download " + httpUrl + " with direct connection.", ex2);
                 }
+            }
+        }
+
+        if (!page.isEmpty() && isClientChallenge(page)) {
+            System.out.println("Client Challenge detected. Try to download " + url + " with ScrapeNinja.");
+            scrapeNinjaUsed = true;
+            try {
+                page = loadWithScrapeNinja(url);
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, "Cannot download " + url + " with ScrapeNinja.", ex);
             }
         }
 
@@ -214,6 +234,10 @@ class Downloader {
             baos.write(buffer, 0, len);
         }
         return baos.toByteArray();
+    }
+
+    private boolean isClientChallenge(String html) {
+        return html != null && html.contains("<title>Client Challenge</title>");
     }
 
     private boolean isSslException(IOException ex) {

--- a/src/test/java/bc/bfi/crawler/DownloaderClientChallengeTest.java
+++ b/src/test/java/bc/bfi/crawler/DownloaderClientChallengeTest.java
@@ -1,0 +1,33 @@
+package bc.bfi.crawler;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class DownloaderClientChallengeTest {
+
+    @Test
+    public void retriesWithScrapeNinjaWhenClientChallenge() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = server.getAddress().getPort();
+        server.createContext("/", (HttpExchange exchange) -> {
+            byte[] body = "<html><head><title>Client Challenge</title></head><body></body></html>".getBytes("UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        try {
+            Downloader downloader = new Downloader();
+            downloader.load("http://localhost:" + port + "/");
+            assertThat(downloader.wasScrapeNinjaUsed(), is(true));
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- retry download via ScrapeNinja when `Client Challenge` title detected
- document the new behavior
- add a unit test for the new fallback logic

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68874c79396c832bbf1aed0b977c0404