### PR TITLE
Improve email parser handling

### DIFF
--- a/src/main/java/bc/bfi/crawler/Parser.java
+++ b/src/main/java/bc/bfi/crawler/Parser.java
@@ -338,6 +338,14 @@ class Parser {
             Map<String, String> canonicalToOriginal = new LinkedHashMap<>();
             Matcher matcher = pattern.matcher(pageContent);
             while (matcher.find()) {
+                int start = matcher.start("value");
+                int end = matcher.end("value");
+                if (start > 0 && Character.isLetterOrDigit(pageContent.charAt(start - 1))) {
+                    continue;
+                }
+                if (end < pageContent.length() && Character.isLetterOrDigit(pageContent.charAt(end))) {
+                    continue;
+                }
                 String email = matcher.group("value");
                 String canonical = email.replaceFirst("^20(?=[A-Za-z0-9])", "");
                 String lower = canonical.toLowerCase(Locale.ENGLISH);

--- a/src/test/java/bc/bfi/crawler/ConcatenatedEmailExclusionTest.java
+++ b/src/test/java/bc/bfi/crawler/ConcatenatedEmailExclusionTest.java
@@ -1,0 +1,20 @@
+package bc.bfi.crawler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class ConcatenatedEmailExclusionTest {
+
+    private final Parser parser = new Parser();
+
+    @Test
+    public void testConcatenatedEmailsAreIgnored() {
+        String html = "ricky1rodgers@aamou.org Director630-606-1910ricky1rodgers@aamou.org "
+                + "WilsonPresidentiwilson@aamou.org iwilson@aamou.org rryder@aamou.org "
+                + "Facilitatorrryder@aamou.org Facilitatorjgreer@aamou.org jgreer@aamou.org "
+                + "erodgers@aamou.org Coordinatorehowell@aamou.org ehowell@aamou.org";
+        String emails = parser.extractEmail(html);
+        assertThat(emails, is("ricky1rodgers@aamou.org\u25d9iwilson@aamou.org\u25d9rryder@aamou.org\u25d9jgreer@aamou.org\u25d9erodgers@aamou.org\u25d9ehowell@aamou.org"));
+    }
+}


### PR DESCRIPTION
## Summary
- filter out emails that are embedded in other words
- add regression test for concatenated emails

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688a52c34630832bba07c62bf2f88b2a