### PR TITLE
Fix 301 redirect handling

### DIFF
--- a/src/main/java/bc/bfi/crawler/Downloader.java
+++ b/src/main/java/bc/bfi/crawler/Downloader.java
@@ -210,6 +210,18 @@ class Downloader {
             String newUrl = connection.getHeaderField("Location");
             String cookies = connection.getHeaderField("Set-Cookie");
 
+            if (newUrl == null && status == HttpURLConnection.HTTP_MOVED_PERM) {
+                URL current = connection.getURL();
+                String host = current.getHost();
+                if (!host.startsWith("www.")) {
+                    newUrl = current.getProtocol() + "://www." + host + current.getFile();
+                }
+            }
+
+            if (newUrl == null) {
+                return connection;
+            }
+
             connection = (HttpURLConnection) new URL(newUrl).openConnection();
             if (headers != null) {
                 for (Map.Entry<String, String> header : headers.entrySet()) {

--- a/src/test/java/bc/bfi/crawler/DownloaderWwwFallbackTest.java
+++ b/src/test/java/bc/bfi/crawler/DownloaderWwwFallbackTest.java
@@ -1,0 +1,45 @@
+package bc.bfi.crawler;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class DownloaderWwwFallbackTest {
+
+    @Test
+    public void retriesWithWwwOnMovedPermanently() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = server.getAddress().getPort();
+        server.createContext("/", (HttpExchange exchange) -> {
+            String host = exchange.getRequestHeaders().getFirst("Host");
+            if (host != null && host.startsWith("www.")) {
+                byte[] body = "with www".getBytes("UTF-8");
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            } else {
+                byte[] body = "<html><head><title>301 Moved Permanently</title></head></html>".getBytes("UTF-8");
+                exchange.sendResponseHeaders(301, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            }
+        });
+        server.start();
+        try {
+            Downloader downloader = new Downloader();
+            Method m = Downloader.class.getDeclaredMethod("loadWithDirectConnection", String.class);
+            m.setAccessible(true);
+            String content = (String) m.invoke(downloader, "http://localhost:" + port + "/");
+            assertThat(content, containsString("with www"));
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- improve `Downloader` redirect logic
- retry with `www.` host if 301 has no Location header
- add test for the new behaviour

## Testing
- `mvn -q -Dtest=DownloaderWwwFallbackTest test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688a5b681130832bacc67f53c62feafb